### PR TITLE
Fixed markdown issues related to Github switch to kramdown.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
-#TimerThree Library#
+TimerThree Library
+==================
 
 Paul Stoffregen's modified TimerThree.  This version provides 2 main benefits:
 
-1: Optimized inline functions - much faster for the most common usage
-2: Support for more boards
+1. Optimized inline functions - much faster for the most common usage
+2. Support for more boards
 
-http://www.pjrc.com/teensy/td_libs_TimerOne.html
-
+http://www.pjrc.com/teensy/td_libs_TimerOne.html  
 https://github.com/PaulStoffregen/TimerThree
 
 Original code
@@ -30,4 +30,3 @@ authors under the GNU GPLv2 license.  Multiple copies of this library, bearing
 the same name but distributed under different license terms, is unfortunately
 confusing.  This copy, with nearly all the code redesigned as inline functions,
 is provided under the "CC BY 3.0 US" license terms.
-


### PR DESCRIPTION
Hi Paul - I hope this pull request doesn't seem petty - it's just a tiny fixup of the README markdown that's necessitated by Github's [switch from Redcarpet to the slightly different Kramdown markup engine](https://github.com/blog/2100-github-pages-now-faster-and-simpler-with-jekyll-3-0).